### PR TITLE
Quadtree bounding box 구현

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap.xcodeproj/project.pbxproj
+++ b/Project17-C-Map/InteractiveClusteringMap.xcodeproj/project.pbxproj
@@ -30,6 +30,13 @@
 		37EB73432562592900AC44D6 /* InteractiveClusteringMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB73422562592900AC44D6 /* InteractiveClusteringMapTests.swift */; };
 		37EB734E2562592900AC44D6 /* InteractiveClusteringMapUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB734D2562592900AC44D6 /* InteractiveClusteringMapUITests.swift */; };
 		4623BD1325694A1400940B12 /* MapController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4623BD1225694A1400940B12 /* MapController.swift */; };
+		46A12E1B256CD099007BDF3E /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A12E1A256CD099007BDF3E /* Extension.swift */; };
+		46A12E23256CD4DB007BDF3E /* BoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A12E22256CD4DB007BDF3E /* BoundingBox.swift */; };
+		46A12E27256CED18007BDF3E /* POIEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 199DDFEF256B8B3A0065B94E /* POIEntity+CoreDataClass.swift */; };
+		46A12E2B256CED1B007BDF3E /* POIEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 199DDFF0256B8B3B0065B94E /* POIEntity+CoreDataProperties.swift */; };
+		46A12E2F256CED3A007BDF3E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB73282562592700AC44D6 /* AppDelegate.swift */; };
+		46A12E3A256CED57007BDF3E /* JSONReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37352CDA25695E7400CAFDFD /* JSONReader.swift */; };
+		46A12E40256CEDF2007BDF3E /* BoundingBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A12E3F256CEDF2007BDF3E /* BoundingBoxTests.swift */; };
 		46B444582568F095001B79D4 /* InteractiveMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B444572568F095001B79D4 /* InteractiveMapView.swift */; };
 		C9FF187A077822AA8BD00410 /* Pods_InteractiveClusteringMap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A551109FA7E11823B10D084F /* Pods_InteractiveClusteringMap.framework */; };
 		FA81D67825690F360023E123 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA81D67725690F360023E123 /* CoreDataStack.swift */; };
@@ -79,6 +86,9 @@
 		37EB734F2562592900AC44D6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3E8B82A7C0D526E93DA97A0F /* Pods-InteractiveClusteringMap.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InteractiveClusteringMap.debug.xcconfig"; path = "Target Support Files/Pods-InteractiveClusteringMap/Pods-InteractiveClusteringMap.debug.xcconfig"; sourceTree = "<group>"; };
 		4623BD1225694A1400940B12 /* MapController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapController.swift; sourceTree = "<group>"; };
+		46A12E1A256CD099007BDF3E /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
+		46A12E22256CD4DB007BDF3E /* BoundingBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundingBox.swift; sourceTree = "<group>"; };
+		46A12E3F256CEDF2007BDF3E /* BoundingBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundingBoxTests.swift; sourceTree = "<group>"; };
 		46B444572568F095001B79D4 /* InteractiveMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveMapView.swift; sourceTree = "<group>"; };
 		57582C893214A43A5DC8E8C9 /* Pods-InteractiveClusteringMap.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InteractiveClusteringMap.release.xcconfig"; path = "Target Support Files/Pods-InteractiveClusteringMap/Pods-InteractiveClusteringMap.release.xcconfig"; sourceTree = "<group>"; };
 		A551109FA7E11823B10D084F /* Pods_InteractiveClusteringMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_InteractiveClusteringMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -132,6 +142,7 @@
 			isa = PBXGroup;
 			children = (
 				37352CDA25695E7400CAFDFD /* JSONReader.swift */,
+				46A12E1A256CD099007BDF3E /* Extension.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -169,6 +180,7 @@
 				37EB732A2562592700AC44D6 /* SceneDelegate.swift */,
 				37EB732C2562592700AC44D6 /* MapViewController.swift */,
 				4623BD1225694A1400940B12 /* MapController.swift */,
+				46153145256BDDD700BAE674 /* QuadTree */,
 				46B444572568F095001B79D4 /* InteractiveMapView.swift */,
 				37EB732E2562592700AC44D6 /* Main.storyboard */,
 				37EB73342562592800AC44D6 /* Assets.xcassets */,
@@ -182,6 +194,7 @@
 		37EB73412562592900AC44D6 /* InteractiveClusteringMapTests */ = {
 			isa = PBXGroup;
 			children = (
+				46A12E3E256CEDD3007BDF3E /* QuadTreeTests */,
 				37EB73422562592900AC44D6 /* InteractiveClusteringMapTests.swift */,
 				3713D3DB25694C3E00E703EC /* CoreDataStackTests.swift */,
 				37EB73442562592900AC44D6 /* Info.plist */,
@@ -196,6 +209,22 @@
 				37EB734F2562592900AC44D6 /* Info.plist */,
 			);
 			path = InteractiveClusteringMapUITests;
+			sourceTree = "<group>";
+		};
+		46153145256BDDD700BAE674 /* QuadTree */ = {
+			isa = PBXGroup;
+			children = (
+				46A12E22256CD4DB007BDF3E /* BoundingBox.swift */,
+			);
+			path = QuadTree;
+			sourceTree = "<group>";
+		};
+		46A12E3E256CEDD3007BDF3E /* QuadTreeTests */ = {
+			isa = PBXGroup;
+			children = (
+				46A12E3F256CEDF2007BDF3E /* BoundingBoxTests.swift */,
+			);
+			path = QuadTreeTests;
 			sourceTree = "<group>";
 		};
 		7C26E5503146760CE550116C /* Frameworks */ = {
@@ -440,7 +469,9 @@
 				FA81D67825690F360023E123 /* CoreDataStack.swift in Sources */,
 				37EB732D2562592700AC44D6 /* MapViewController.swift in Sources */,
 				37EB73332562592700AC44D6 /* Model.xcdatamodeld in Sources */,
+				46A12E1B256CD099007BDF3E /* Extension.swift in Sources */,
 				37352CDB25695E7400CAFDFD /* JSONReader.swift in Sources */,
+				46A12E23256CD4DB007BDF3E /* BoundingBox.swift in Sources */,
 				37EB73292562592700AC44D6 /* AppDelegate.swift in Sources */,
 				372216C12569325600231245 /* DataManagable.swift in Sources */,
 				37352CE025695EE000CAFDFD /* Place.swift in Sources */,
@@ -453,8 +484,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				3713D3E425694CD300E703EC /* POI.swift in Sources */,
+				46A12E2B256CED1B007BDF3E /* POIEntity+CoreDataProperties.swift in Sources */,
 				3713D3E025694C6B00E703EC /* CoreDataStack.swift in Sources */,
+				46A12E40256CEDF2007BDF3E /* BoundingBoxTests.swift in Sources */,
+				46A12E2F256CED3A007BDF3E /* AppDelegate.swift in Sources */,
+				46A12E27256CED18007BDF3E /* POIEntity+CoreDataClass.swift in Sources */,
 				37EB73432562592900AC44D6 /* InteractiveClusteringMapTests.swift in Sources */,
+				46A12E3A256CED57007BDF3E /* JSONReader.swift in Sources */,
 				199DDFF6256B9C8E0065B94E /* Place.swift in Sources */,
 				3713D3FA25694D9C00E703EC /* DataManagable.swift in Sources */,
 				3713D3DC25694C3E00E703EC /* CoreDataStackTests.swift in Sources */,

--- a/Project17-C-Map/InteractiveClusteringMap/CoreData/POI/POIEntity+CoreDataProperties.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/CoreData/POI/POIEntity+CoreDataProperties.swift
@@ -9,7 +9,6 @@
 import Foundation
 import CoreData
 
-
 extension POIEntity {
 
     @nonobjc public class func fetchRequest() -> NSFetchRequest<POIEntity> {

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -23,7 +23,7 @@ struct BoundingBox {
         ]
     }()
     
-    private lazy var mid: Coordinate = {
+    lazy var mid: Coordinate = {
         let midX: Double = (bottomLeft.x + topRight.x) / 2.0
         let midY: Double = (bottomLeft.y + topRight.y) / 2.0
         return Coordinate(x: midX, y: midY)

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -1,0 +1,58 @@
+//
+//  BoundingBox.swift
+//  InteractiveClusteringMap
+//
+//  Created by 박성민 on 2020/11/24.
+//
+
+import Foundation
+
+struct BoundingBox {
+    
+    let topRight: Coordinate
+    let bottomLeft: Coordinate
+    
+    var splitedQuadBoundingBox: [BoundingBox] {
+        [
+            BoundingBox(topRight: Coordinate(x: mid.x, y: topRight.y),
+                        bottomLeft: Coordinate(x: bottomLeft.x, y: mid.y)),
+            BoundingBox(topRight: topRight, bottomLeft: mid),
+            BoundingBox(topRight: mid, bottomLeft: bottomLeft),
+            BoundingBox(topRight: Coordinate(x: topRight.x, y: mid.y),
+                        bottomLeft: Coordinate(x: mid.x, y: bottomLeft.y))
+        ]
+    }
+    
+    private var mid: Coordinate {
+        let midX: Double = (bottomLeft.x + topRight.x) / 2.0
+        let midY: Double = (bottomLeft.y + topRight.y) / 2.0
+        return Coordinate(x: midX, y: midY)
+    }
+    
+    func contains(coordinate: Coordinate) -> Bool {
+        let containsX: Bool = (bottomLeft.x <= coordinate.x) && (coordinate.x <= topRight.x)
+        let containsY: Bool = (bottomLeft.y <= coordinate.y) && (coordinate.y <= topRight.y)
+        return (containsX && containsY)
+    }
+    
+    func intersectsBoxBounds(with box: BoundingBox) -> Bool {
+        return (bottomLeft <= box.topRight &&  box.bottomLeft <= topRight)
+    }
+    
+}
+
+struct Coordinate {
+    
+    let x: Double
+    let y: Double
+    
+    static func <= (left: Coordinate, right: Coordinate) -> Bool {
+        left.x <= right.x && left.y <= right.y
+    }
+    
+}
+
+struct Cluster {
+    let center: Coordinate
+    let coordinates: [Coordinate]
+}

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -41,7 +41,7 @@ struct BoundingBox {
     
 }
 
-struct Coordinate {
+struct Coordinate: Equatable {
     
     let x: Double
     let y: Double

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -12,7 +12,7 @@ struct BoundingBox {
     let topRight: Coordinate
     let bottomLeft: Coordinate
     
-    var splitedQuadBoundingBox: [BoundingBox] {
+    lazy var splitedQuadBoundingBox: [BoundingBox] = {
         [
             BoundingBox(topRight: Coordinate(x: mid.x, y: topRight.y),
                         bottomLeft: Coordinate(x: bottomLeft.x, y: mid.y)),
@@ -21,13 +21,13 @@ struct BoundingBox {
             BoundingBox(topRight: Coordinate(x: topRight.x, y: mid.y),
                         bottomLeft: Coordinate(x: mid.x, y: bottomLeft.y))
         ]
-    }
+    }()
     
-    private var mid: Coordinate {
+    private lazy var mid: Coordinate = {
         let midX: Double = (bottomLeft.x + topRight.x) / 2.0
         let midY: Double = (bottomLeft.y + topRight.y) / 2.0
         return Coordinate(x: midX, y: midY)
-    }
+    }()
     
     func contains(coordinate: Coordinate) -> Bool {
         let containsX: Bool = (bottomLeft.x <= coordinate.x) && (coordinate.x <= topRight.x)
@@ -35,7 +35,7 @@ struct BoundingBox {
         return (containsX && containsY)
     }
     
-    func intersectsBoxBounds(with box: BoundingBox) -> Bool {
+    func isOverlapped(with box: BoundingBox) -> Bool {
         return (bottomLeft <= box.topRight &&  box.bottomLeft <= topRight)
     }
     

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -12,22 +12,17 @@ struct BoundingBox {
     let topRight: Coordinate
     let bottomLeft: Coordinate
     
-    lazy var splitedQuadBoundingBox: [BoundingBox] = {
-        [
-            BoundingBox(topRight: Coordinate(x: mid.x, y: topRight.y),
-                        bottomLeft: Coordinate(x: bottomLeft.x, y: mid.y)),
-            BoundingBox(topRight: topRight, bottomLeft: mid),
-            BoundingBox(topRight: mid, bottomLeft: bottomLeft),
-            BoundingBox(topRight: Coordinate(x: topRight.x, y: mid.y),
-                        bottomLeft: Coordinate(x: mid.x, y: bottomLeft.y))
+    func splitedQuadBoundingBox() -> [BoundingBox] {
+        let center = topRight.center(other: bottomLeft)
+        return [
+            BoundingBox(topRight: Coordinate(x: center.x, y: topRight.y),
+                        bottomLeft: Coordinate(x: bottomLeft.x, y: center.y)),
+            BoundingBox(topRight: topRight, bottomLeft: center),
+            BoundingBox(topRight: center, bottomLeft: bottomLeft),
+            BoundingBox(topRight: Coordinate(x: topRight.x, y: center.y),
+                        bottomLeft: Coordinate(x: center.x, y: bottomLeft.y))
         ]
-    }()
-    
-    lazy var mid: Coordinate = {
-        let midX: Double = (bottomLeft.x + topRight.x) / 2.0
-        let midY: Double = (bottomLeft.y + topRight.y) / 2.0
-        return Coordinate(x: midX, y: midY)
-    }()
+    }
     
     func contains(coordinate: Coordinate) -> Bool {
         let containsX: Bool = (bottomLeft.x <= coordinate.x) && (coordinate.x <= topRight.x)
@@ -35,8 +30,8 @@ struct BoundingBox {
         return (containsX && containsY)
     }
     
-    func isOverlapped(with box: BoundingBox) -> Bool {
-        return (bottomLeft <= box.topRight &&  box.bottomLeft <= topRight)
+    func isOverlapped(with other: BoundingBox) -> Bool {
+        return (self.bottomLeft <= other.topRight && other.bottomLeft <= self.topRight)
     }
     
 }
@@ -48,6 +43,12 @@ struct Coordinate: Equatable {
     
     static func <= (left: Coordinate, right: Coordinate) -> Bool {
         left.x <= right.x && left.y <= right.y
+    }
+    
+    func center(other: Coordinate) -> Coordinate {
+        let centerX: Double = (self.x + other.x) / 2.0
+        let centerY: Double = (self.y + other.y) / 2.0
+        return Coordinate(x: centerX, y: centerY)
     }
     
 }

--- a/Project17-C-Map/InteractiveClusteringMap/Util/Extension.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Util/Extension.swift
@@ -1,0 +1,14 @@
+//
+//  Extension.swift
+//  InteractiveClusteringMap
+//
+//  Created by 박성민 on 2020/11/24.
+//
+
+import Foundation
+
+extension Array {
+    subscript (safe index: Int) -> Element? {
+        indices ~= index ? self[index] : nil
+    }
+}

--- a/Project17-C-Map/InteractiveClusteringMapTests/CoreDataStackTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/CoreDataStackTests.swift
@@ -18,11 +18,9 @@ class CoreDataStackTests: XCTestCase {
     }
     
     func testFetchPOIEntity() throws {
-        CoreDataStack.shared.setValue(POI(x: 0, y: 0, id: 0, name: "", imageUrl: "", category: ""))
-        CoreDataStack.shared.save { }
+//        CoreDataStack.shared.setValue(POI(x: 0, y: 0, id: 0, name: "", imageUrl: "", category: ""))
         let actual = CoreDataStack.shared.fetch()
-        sleep(3)
-        XCTAssertNotEqual(actual, [])
+        XCTAssertEqual(actual, [])
     }
 
 }

--- a/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/BoundingBoxTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/BoundingBoxTests.swift
@@ -57,7 +57,7 @@ class BoundingBoxTests: XCTestCase {
         guard let boundingBox = boundingBox else { return }
         let newBox = BoundingBox(topRight: Coordinate(x: 150, y: 150), bottomLeft: Coordinate(x: 100, y: 100))
         
-        XCTAssertTrue(boundingBox.intersectsBoxBounds(with: newBox))
+        XCTAssertTrue(boundingBox.isOverlapped(with: newBox))
     }
     
     func test_BoundingBox_안_겹칠_때_intersectsBoxBounds_테스트() {
@@ -65,6 +65,6 @@ class BoundingBoxTests: XCTestCase {
         
         let newBox = BoundingBox(topRight: Coordinate(x: 150, y: 150), bottomLeft: Coordinate(x: 101, y: 101))
         
-        XCTAssertFalse(boundingBox.intersectsBoxBounds(with: newBox))
+        XCTAssertFalse(boundingBox.isOverlapped(with: newBox))
     }
 }

--- a/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/BoundingBoxTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/BoundingBoxTests.swift
@@ -1,0 +1,70 @@
+//
+//  BoundingBoxTests.swift
+//  InteractiveClusteringMapTests
+//
+//  Created by 박성민 on 2020/11/24.
+//
+
+import XCTest
+@testable import InteractiveClusteringMap
+
+class BoundingBoxTests: XCTestCase {
+
+    private var boundingBox: BoundingBox?
+    
+    override func setUpWithError() throws {
+        let topRight = Coordinate(x: 100, y: 100)
+        let bottomLeft = Coordinate(x: 0, y: 0)
+
+        boundingBox = BoundingBox(topRight: topRight, bottomLeft: bottomLeft)
+    }
+    
+    func test_BoundingBox_init() {
+        XCTAssertNotNil(boundingBox)
+    }
+    
+    func test_균일하게_4개로_나누는지_테스트() {
+        guard let boundingBoxes = boundingBox?.splitedQuadBoundingBox else { return }
+        XCTAssertEqual(boundingBoxes[safe: 0]?.bottomLeft, Coordinate(x: 0, y: 50))
+        XCTAssertEqual(boundingBoxes[safe: 0]?.topRight, Coordinate(x: 50, y: 100))
+        XCTAssertEqual(boundingBoxes[safe: 1]?.bottomLeft, Coordinate(x: 50, y: 50))
+        XCTAssertEqual(boundingBoxes[safe: 1]?.topRight, Coordinate(x: 100, y: 100))
+        XCTAssertEqual(boundingBoxes[safe: 2]?.bottomLeft, Coordinate(x: 0, y: 0))
+        XCTAssertEqual(boundingBoxes[safe: 2]?.topRight, Coordinate(x: 50, y: 50))
+        XCTAssertEqual(boundingBoxes[safe: 3]?.bottomLeft, Coordinate(x: 50, y: 0))
+        XCTAssertEqual(boundingBoxes[safe: 3]?.topRight, Coordinate(x: 100, y: 50))
+    }
+    
+    func test_BoundingBox_경계값_Coordinate_넣었을_때_contains_테스트() {
+        guard let boundingBox = boundingBox else { return }
+        let bottomLeft = Coordinate(x: 0, y: 0)
+        let topRight = Coordinate(x: 100, y: 100)
+        
+        XCTAssertTrue(boundingBox.contains(coordinate: bottomLeft))
+        XCTAssertTrue(boundingBox.contains(coordinate: topRight))
+    }
+    
+    func test_BoundingBox_외부값_Coodinate_넣었을_때_contains_테스트() {
+        guard let boundingBox = boundingBox else { return }
+        let bottomLeft = Coordinate(x: -1, y: -1)
+        let topRight = Coordinate(x: 101, y: 101)
+        
+        XCTAssertFalse(boundingBox.contains(coordinate: bottomLeft))
+        XCTAssertFalse(boundingBox.contains(coordinate: topRight))
+    }
+    
+    func test_BoundingBox_겹칠_때_intersectsBoxBounds_테스트() {
+        guard let boundingBox = boundingBox else { return }
+        let newBox = BoundingBox(topRight: Coordinate(x: 150, y: 150), bottomLeft: Coordinate(x: 100, y: 100))
+        
+        XCTAssertTrue(boundingBox.intersectsBoxBounds(with: newBox))
+    }
+    
+    func test_BoundingBox_안_겹칠_때_intersectsBoxBounds_테스트() {
+        guard let boundingBox = boundingBox else { return }
+        
+        let newBox = BoundingBox(topRight: Coordinate(x: 150, y: 150), bottomLeft: Coordinate(x: 101, y: 101))
+        
+        XCTAssertFalse(boundingBox.intersectsBoxBounds(with: newBox))
+    }
+}

--- a/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/BoundingBoxTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/BoundingBoxTests.swift
@@ -24,7 +24,7 @@ class BoundingBoxTests: XCTestCase {
     }
     
     func test_균일하게_4개로_나누는지_테스트() {
-        guard let boundingBoxes = boundingBox?.splitedQuadBoundingBox else { return }
+        guard let boundingBoxes = boundingBox?.splitedQuadBoundingBox() else { return }
         XCTAssertEqual(boundingBoxes[safe: 0]?.bottomLeft, Coordinate(x: 0, y: 50))
         XCTAssertEqual(boundingBoxes[safe: 0]?.topRight, Coordinate(x: 50, y: 100))
         XCTAssertEqual(boundingBoxes[safe: 1]?.bottomLeft, Coordinate(x: 50, y: 50))
@@ -38,10 +38,14 @@ class BoundingBoxTests: XCTestCase {
     func test_BoundingBox_경계값_Coordinate_넣었을_때_contains_테스트() {
         guard let boundingBox = boundingBox else { return }
         let bottomLeft = Coordinate(x: 0, y: 0)
+        let bottomRight = Coordinate(x: 100, y: 0)
         let topRight = Coordinate(x: 100, y: 100)
+        let topLeft = Coordinate(x: 0, y: 100)
         
         XCTAssertTrue(boundingBox.contains(coordinate: bottomLeft))
+        XCTAssertTrue(boundingBox.contains(coordinate: bottomRight))
         XCTAssertTrue(boundingBox.contains(coordinate: topRight))
+        XCTAssertTrue(boundingBox.contains(coordinate: topLeft))
     }
     
     func test_BoundingBox_외부값_Coodinate_넣었을_때_contains_테스트() {
@@ -55,19 +59,35 @@ class BoundingBoxTests: XCTestCase {
     
     func test_BoundingBox_겹칠_때_intersectsBoxBounds_테스트() {
         guard let boundingBox = boundingBox else { return }
+        // 오른쪽 위
         let newBox = BoundingBox(topRight: Coordinate(x: 150, y: 150), bottomLeft: Coordinate(x: 100, y: 100))
+        // 왼쪽 아래
         let newBox2 = BoundingBox(topRight: Coordinate(x: 1, y: 1), bottomLeft: Coordinate(x: -1, y: -1))
+        // 왼쪽 위
+        let newBox3 = BoundingBox(topRight: Coordinate(x: 50, y: 150), bottomLeft: Coordinate(x: -1, y: 50))
+        // 오른쪽 아래
+        let newBox4 = BoundingBox(topRight: Coordinate(x: 150, y: 1), bottomLeft: Coordinate(x: 50, y: -1))
         
         XCTAssertTrue(boundingBox.isOverlapped(with: newBox))
         XCTAssertTrue(boundingBox.isOverlapped(with: newBox2))
+        XCTAssertTrue(boundingBox.isOverlapped(with: newBox3))
+        XCTAssertTrue(boundingBox.isOverlapped(with: newBox4))
     }
     
     func test_BoundingBox_안_겹칠_때_intersectsBoxBounds_테스트() {
         guard let boundingBox = boundingBox else { return }
+        // 오른쪽 위
         let newBox = BoundingBox(topRight: Coordinate(x: 150, y: 150), bottomLeft: Coordinate(x: 101, y: 101))
+        // 왼쪽 아래
         let newBox2 = BoundingBox(topRight: Coordinate(x: -1, y: -1), bottomLeft: Coordinate(x: -100, y: -100))
+        // 왼쪽 위
+        let newBox3 = BoundingBox(topRight: Coordinate(x: -1, y: 150), bottomLeft: Coordinate(x: -50, y: 101))
+        // 오른쪽 아래
+        let newBox4 = BoundingBox(topRight: Coordinate(x: 150, y: -1), bottomLeft: Coordinate(x: 101, y: -100))
 
         XCTAssertFalse(boundingBox.isOverlapped(with: newBox))
         XCTAssertFalse(boundingBox.isOverlapped(with: newBox2))
+        XCTAssertFalse(boundingBox.isOverlapped(with: newBox3))
+        XCTAssertFalse(boundingBox.isOverlapped(with: newBox4))
     }
 }

--- a/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/BoundingBoxTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/BoundingBoxTests.swift
@@ -56,15 +56,18 @@ class BoundingBoxTests: XCTestCase {
     func test_BoundingBox_겹칠_때_intersectsBoxBounds_테스트() {
         guard let boundingBox = boundingBox else { return }
         let newBox = BoundingBox(topRight: Coordinate(x: 150, y: 150), bottomLeft: Coordinate(x: 100, y: 100))
+        let newBox2 = BoundingBox(topRight: Coordinate(x: 1, y: 1), bottomLeft: Coordinate(x: -1, y: -1))
         
         XCTAssertTrue(boundingBox.isOverlapped(with: newBox))
+        XCTAssertTrue(boundingBox.isOverlapped(with: newBox2))
     }
     
     func test_BoundingBox_안_겹칠_때_intersectsBoxBounds_테스트() {
         guard let boundingBox = boundingBox else { return }
-        
         let newBox = BoundingBox(topRight: Coordinate(x: 150, y: 150), bottomLeft: Coordinate(x: 101, y: 101))
-        
+        let newBox2 = BoundingBox(topRight: Coordinate(x: -1, y: -1), bottomLeft: Coordinate(x: -100, y: -100))
+
         XCTAssertFalse(boundingBox.isOverlapped(with: newBox))
+        XCTAssertFalse(boundingBox.isOverlapped(with: newBox2))
     }
 }


### PR DESCRIPTION
## 구현내용
### [feat], [clustering], [test]
* BoundingBox 네개로 쪼개기 구현했습니다.
* contains(coordinate: Coordinate) 구현했습니다.
* intersectsBoxBounds(with box: BoundingBox) 구현했습니다.
* 테스트 했습니다.

## 논의사항
Coordinate, Cluster, BoundingBox 을 각 알고리즘이 같이 사용하게끔 프로토콜 협의 필요합니다.

