### PR TITLE
K 결정 및 알고리즘 성능 판단(실루엣 이용) 함수 추가, 테스트

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap.xcodeproj/project.pbxproj
+++ b/Project17-C-Map/InteractiveClusteringMap.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		46B444582568F095001B79D4 /* InteractiveMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B444572568F095001B79D4 /* InteractiveMapView.swift */; };
 		C9FF187A077822AA8BD00410 /* Pods_InteractiveClusteringMap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A551109FA7E11823B10D084F /* Pods_InteractiveClusteringMap.framework */; };
 		FA81D67825690F360023E123 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA81D67725690F360023E123 /* CoreDataStack.swift */; };
+		FA84D560256F796700ECDD44 /* BoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A12E22256CD4DB007BDF3E /* BoundingBox.swift */; };
 		FAC9FD05256E2107009FBB41 /* KCoefficient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9FD04256E2107009FBB41 /* KCoefficient.swift */; };
 		FAC9FD0A256E23B1009FBB41 /* KDefineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9FD09256E23B1009FBB41 /* KDefineTests.swift */; };
 		FAC9FD0E256E2495009FBB41 /* KCoefficient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9FD04256E2107009FBB41 /* KCoefficient.swift */; };
@@ -500,6 +501,7 @@
 				46A12E27256CED18007BDF3E /* POIEntity+CoreDataClass.swift in Sources */,
 				37EB73432562592900AC44D6 /* InteractiveClusteringMapTests.swift in Sources */,
 				46A12E3A256CED57007BDF3E /* JSONReader.swift in Sources */,
+				FA84D560256F796700ECDD44 /* BoundingBox.swift in Sources */,
 				199DDFF6256B9C8E0065B94E /* Place.swift in Sources */,
 				3713D3FA25694D9C00E703EC /* DataManagable.swift in Sources */,
 				FAC9FD0A256E23B1009FBB41 /* KDefineTests.swift in Sources */,

--- a/Project17-C-Map/InteractiveClusteringMap.xcodeproj/project.pbxproj
+++ b/Project17-C-Map/InteractiveClusteringMap.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		FA81D67825690F360023E123 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA81D67725690F360023E123 /* CoreDataStack.swift */; };
 		FAC9FD05256E2107009FBB41 /* KCoefficient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9FD04256E2107009FBB41 /* KCoefficient.swift */; };
 		FAC9FD0A256E23B1009FBB41 /* KDefineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9FD09256E23B1009FBB41 /* KDefineTests.swift */; };
+		FAC9FD0E256E2495009FBB41 /* KCoefficient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9FD04256E2107009FBB41 /* KCoefficient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -490,6 +491,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FAC9FD0E256E2495009FBB41 /* KCoefficient.swift in Sources */,
 				3713D3E425694CD300E703EC /* POI.swift in Sources */,
 				46A12E2B256CED1B007BDF3E /* POIEntity+CoreDataProperties.swift in Sources */,
 				3713D3E025694C6B00E703EC /* CoreDataStack.swift in Sources */,

--- a/Project17-C-Map/InteractiveClusteringMap.xcodeproj/project.pbxproj
+++ b/Project17-C-Map/InteractiveClusteringMap.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		46B444582568F095001B79D4 /* InteractiveMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B444572568F095001B79D4 /* InteractiveMapView.swift */; };
 		C9FF187A077822AA8BD00410 /* Pods_InteractiveClusteringMap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A551109FA7E11823B10D084F /* Pods_InteractiveClusteringMap.framework */; };
 		FA81D67825690F360023E123 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA81D67725690F360023E123 /* CoreDataStack.swift */; };
+		FAC9FD05256E2107009FBB41 /* KCoefficient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9FD04256E2107009FBB41 /* KCoefficient.swift */; };
+		FAC9FD0A256E23B1009FBB41 /* KDefineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9FD09256E23B1009FBB41 /* KDefineTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +95,8 @@
 		57582C893214A43A5DC8E8C9 /* Pods-InteractiveClusteringMap.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InteractiveClusteringMap.release.xcconfig"; path = "Target Support Files/Pods-InteractiveClusteringMap/Pods-InteractiveClusteringMap.release.xcconfig"; sourceTree = "<group>"; };
 		A551109FA7E11823B10D084F /* Pods_InteractiveClusteringMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_InteractiveClusteringMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA81D67725690F360023E123 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
+		FAC9FD04256E2107009FBB41 /* KCoefficient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KCoefficient.swift; sourceTree = "<group>"; };
+		FAC9FD09256E23B1009FBB41 /* KDefineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KDefineTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -178,6 +182,7 @@
 				FA81D66E2568FEC50023E123 /* CoreData */,
 				37EB73282562592700AC44D6 /* AppDelegate.swift */,
 				37EB732A2562592700AC44D6 /* SceneDelegate.swift */,
+				FAC9FD04256E2107009FBB41 /* KCoefficient.swift */,
 				37EB732C2562592700AC44D6 /* MapViewController.swift */,
 				4623BD1225694A1400940B12 /* MapController.swift */,
 				46153145256BDDD700BAE674 /* QuadTree */,
@@ -197,6 +202,7 @@
 				46A12E3E256CEDD3007BDF3E /* QuadTreeTests */,
 				37EB73422562592900AC44D6 /* InteractiveClusteringMapTests.swift */,
 				3713D3DB25694C3E00E703EC /* CoreDataStackTests.swift */,
+				FAC9FD09256E23B1009FBB41 /* KDefineTests.swift */,
 				37EB73442562592900AC44D6 /* Info.plist */,
 			);
 			path = InteractiveClusteringMapTests;
@@ -472,6 +478,7 @@
 				46A12E1B256CD099007BDF3E /* Extension.swift in Sources */,
 				37352CDB25695E7400CAFDFD /* JSONReader.swift in Sources */,
 				46A12E23256CD4DB007BDF3E /* BoundingBox.swift in Sources */,
+				FAC9FD05256E2107009FBB41 /* KCoefficient.swift in Sources */,
 				37EB73292562592700AC44D6 /* AppDelegate.swift in Sources */,
 				372216C12569325600231245 /* DataManagable.swift in Sources */,
 				37352CE025695EE000CAFDFD /* Place.swift in Sources */,
@@ -493,6 +500,7 @@
 				46A12E3A256CED57007BDF3E /* JSONReader.swift in Sources */,
 				199DDFF6256B9C8E0065B94E /* Place.swift in Sources */,
 				3713D3FA25694D9C00E703EC /* DataManagable.swift in Sources */,
+				FAC9FD0A256E23B1009FBB41 /* KDefineTests.swift in Sources */,
 				3713D3DC25694C3E00E703EC /* CoreDataStackTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -15,7 +15,7 @@ func KwithRuleOfThumb(numberOfData: Int) -> Int {
 // AverageSilhouetteMethod
 class AverageSilhouetteCalculator {
     
-    let clusters: [Cluster]
+    private let clusters: [Cluster]
     
     init(clusters: [Cluster]) {
         self.clusters = clusters
@@ -44,7 +44,7 @@ class AverageSilhouetteCalculator {
         cluster.coordinates.forEach {
             totalDistance += target.distanceTo($0)
         }
-        return totalDistance / Double(cluster.coordinates.count)
+        return totalDistance / Double(cluster.coordinates.count - 1)
     }
 
     // 점과 포함되지 않은 클러스터 간의 분리도 계산

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -41,18 +41,21 @@ class AverageSilhouetteCalculator {
     // 점과 현재 포함된 클러스터의 응집도 계산
     func findCohesion(in cluster: Cluster, target: Coordinate) -> Double {
         var totalDistance = 0.0
-        cluster.coordinates.forEach {
+        let coordinates = cluster.coordinates.filter { $0 != target }
+        coordinates.forEach {
             totalDistance += target.distanceTo($0)
         }
-        return totalDistance / Double(cluster.coordinates.count - 1)
+        return totalDistance / Double(coordinates.count)
     }
 
     // 점과 포함되지 않은 클러스터 간의 분리도 계산
     func findSeparation(in cluster: Cluster, target: Coordinate) -> Double {
         var totalDistances: [Double] = [Double]()
-        let otherClusters = clusters.filter { $0 != cluster }
+        let otherClusters = clusters.filter { $0.coordinates != cluster.coordinates }
         otherClusters.forEach {
             totalDistances.append(findCohesion(in: $0, target: target))
+            print("================")
+            print(totalDistances)
         }
         return totalDistances.min() ?? 0
     }

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -21,11 +21,12 @@ class AverageSilhouetteCalculator {
     }
     
     // AverageSilhouetteMethod
-    func findAverageSilhouette() {
-        clusters.forEach { cluster in
-           
+    func findAverageSilhouette(cluster: Cluster) -> Double {
+        var silhouettes  = [Double]()
+        cluster.coordinates.forEach { coordinate in
+            silhouettes.append(findSilhouette(with: cluster, target: coordinate))
         }
-        
+        return silhouettes.reduce(.zero, +) / Double(silhouettes.count)
     }
 
     func findSilhouette(with cluster: Cluster, target: Coordinate) -> Double {

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -54,8 +54,6 @@ class AverageSilhouetteCalculator {
         let otherClusters = clusters.filter { $0.coordinates != cluster.coordinates }
         otherClusters.forEach {
             totalDistances.append(findCohesion(in: $0, target: target))
-            print("================")
-            print(totalDistances)
         }
         return totalDistances.min() ?? 0
     }

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // rule of thumb
 func KwithRuleOfThumb(numberOfData: Int) -> Int {
-    return Int(sqrt(Double(numberOfData/2)))
+    Int(sqrt(Double(numberOfData/2)))
 }
 
 // AverageSilhouetteMethod
@@ -21,25 +21,25 @@ class AverageSilhouetteCalculator {
         self.clusters = clusters
     }
     
-    func findAverageSilhouette(cluster: Cluster) -> Double {
-        var silhouettes  = [Double]()
+    func calculateAverageSilhouette(cluster: Cluster) -> Double {
+        var silhouettes = [Double]()
         cluster.coordinates.forEach { coordinate in
-            silhouettes.append(findSilhouette(with: cluster, target: coordinate))
+            silhouettes.append(calculateSilhouette(with: cluster, target: coordinate))
         }
         return silhouettes.reduce(.zero, +) / Double(silhouettes.count)
     }
 
-    func findSilhouette(with cluster: Cluster, target: Coordinate) -> Double {
+    func calculateSilhouette(with cluster: Cluster, target: Coordinate) -> Double {
         guard !cluster.coordinates.isEmpty else {
             return 0.0
         }
-        let cohesion = findCohesion(in: cluster, target: target)
-        let separation = findSeparation(in: cluster, target: target)
+        let cohesion = calculateCohesion(in: cluster, target: target)
+        let separation = calculateSeparation(in: cluster, target: target)
         return (separation - cohesion) / max(cohesion, separation)
     }
 
     // 점과 현재 포함된 클러스터의 응집도 계산
-    func findCohesion(in cluster: Cluster, target: Coordinate) -> Double {
+    func calculateCohesion(in cluster: Cluster, target: Coordinate) -> Double {
         var totalDistance = 0.0
         let coordinates = cluster.coordinates.filter { $0 != target }
         coordinates.forEach {
@@ -49,11 +49,11 @@ class AverageSilhouetteCalculator {
     }
 
     // 점과 포함되지 않은 클러스터 간의 분리도 계산
-    func findSeparation(in cluster: Cluster, target: Coordinate) -> Double {
+    func calculateSeparation(in cluster: Cluster, target: Coordinate) -> Double {
         var totalDistances: [Double] = [Double]()
         let otherClusters = clusters.filter { $0.coordinates != cluster.coordinates }
         otherClusters.forEach {
-            totalDistances.append(findCohesion(in: $0, target: target))
+            totalDistances.append(calculateCohesion(in: $0, target: target))
         }
         return totalDistances.min() ?? 0
     }

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
-func KwithRuleOfThumb(numberOfData : Int) -> Int {
+// rule of thumb
+func KwithRuleOfThumb(numberOfData: Int) -> Int {
     return Int(sqrt(Double(numberOfData/2)))
 }
+

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -1,0 +1,12 @@
+//
+//  KCoefficient.swift
+//  InteractiveClusteringMap
+//
+//  Created by A on 2020/11/25.
+//
+
+import Foundation
+
+func KwithRuleOfThumb(numberOfData : Int) -> Int {
+    return Int(sqrt(Double(numberOfData/2)))
+}

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -14,15 +14,21 @@ func KwithRuleOfThumb(numberOfData: Int) -> Int {
 
 class AverageSilhouetteCalculator {
     
+    let clusters: [Cluster]
+    
+    init(clusters: [Cluster]) {
+        self.clusters = clusters
+    }
+    
     // AverageSilhouetteMethod
-    func findAverageSilhouette(with clusters: [Cluster]) {
+    func findAverageSilhouette() {
         clusters.forEach { cluster in
            
         }
         
     }
 
-    func findSilhoutte(with cluster: Cluster, target: Coordinate) -> Double {
+    func findSilhouette(with cluster: Cluster, target: Coordinate) -> Double {
         guard !cluster.coordinates.isEmpty else {
             return 0.0
         }
@@ -40,7 +46,12 @@ class AverageSilhouetteCalculator {
     }
 
     func findSeparation(in cluster: Cluster, target: Coordinate) -> Double {
-        var totalDistances: [Double] = []()
+        var totalDistances: [Double] = [Double]()
+        let otherClusters = clusters.filter { $0 != cluster }
+        otherClusters.forEach {
+            totalDistances.append(findCohesion(in: $0, target: target))
+        }
+        return totalDistances.min() ?? 0
     }
+    
 }
-

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -12,3 +12,35 @@ func KwithRuleOfThumb(numberOfData: Int) -> Int {
     return Int(sqrt(Double(numberOfData/2)))
 }
 
+class AverageSilhouetteCalculator {
+    
+    // AverageSilhouetteMethod
+    func findAverageSilhouette(with clusters: [Cluster]) {
+        clusters.forEach { cluster in
+           
+        }
+        
+    }
+
+    func findSilhoutte(with cluster: Cluster, target: Coordinate) -> Double {
+        guard !cluster.coordinates.isEmpty else {
+            return 0.0
+        }
+        let cohesion = findCohesion(in: cluster, target: target)
+        let separation = findSeparation(in: cluster, target: target)
+        return (separation - cohesion) / max(cohesion, separation)
+    }
+
+    func findCohesion(in cluster: Cluster, target: Coordinate) -> Double {
+        var totalDistance = 0.0
+        cluster.coordinates.forEach {
+            totalDistance += target.distanceTo($0)
+        }
+        return totalDistance / Double(cluster.coordinates.count)
+    }
+
+    func findSeparation(in cluster: Cluster, target: Coordinate) -> Double {
+        var totalDistances: [Double] = []()
+    }
+}
+

--- a/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/KCoefficient.swift
@@ -12,6 +12,7 @@ func KwithRuleOfThumb(numberOfData: Int) -> Int {
     return Int(sqrt(Double(numberOfData/2)))
 }
 
+// AverageSilhouetteMethod
 class AverageSilhouetteCalculator {
     
     let clusters: [Cluster]
@@ -20,7 +21,6 @@ class AverageSilhouetteCalculator {
         self.clusters = clusters
     }
     
-    // AverageSilhouetteMethod
     func findAverageSilhouette(cluster: Cluster) -> Double {
         var silhouettes  = [Double]()
         cluster.coordinates.forEach { coordinate in
@@ -38,6 +38,7 @@ class AverageSilhouetteCalculator {
         return (separation - cohesion) / max(cohesion, separation)
     }
 
+    // 점과 현재 포함된 클러스터의 응집도 계산
     func findCohesion(in cluster: Cluster, target: Coordinate) -> Double {
         var totalDistance = 0.0
         cluster.coordinates.forEach {
@@ -46,6 +47,7 @@ class AverageSilhouetteCalculator {
         return totalDistance / Double(cluster.coordinates.count)
     }
 
+    // 점과 포함되지 않은 클러스터 간의 분리도 계산
     func findSeparation(in cluster: Cluster, target: Coordinate) -> Double {
         var totalDistances: [Double] = [Double]()
         let otherClusters = clusters.filter { $0 != cluster }

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -41,6 +41,31 @@ struct Coordinate: Equatable {
     let x: Double
     let y: Double
     
+    func distanceTo(_ other: Coordinate) -> Double {
+        let powX = pow(self.x - other.x, 2.0)
+        let powY = pow(self.y - other.y, 2.0)
+        
+        return sqrt(powX + powY)
+    }
+    
+    static func + (left: Coordinate, right: Coordinate) -> Coordinate {
+        let x = left.x + right.x
+        let y = left.y + right.y
+        return Coordinate(x: x, y: y)
+    }
+    
+    static func - (left: Coordinate, right: Coordinate) -> Coordinate {
+        let x = left.x - right.x
+        let y = left.y - right.y
+        return Coordinate(x: x, y: y)
+    }
+    
+    static func / (left: Coordinate, right: Double) -> Coordinate {
+        let x = left.x / right
+        let y = left.y / right
+        return Coordinate(x: x, y: y)
+    }
+    
     static func <= (left: Coordinate, right: Coordinate) -> Bool {
         left.x <= right.x && left.y <= right.y
     }

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -78,7 +78,7 @@ struct Coordinate: Equatable {
     
 }
 
-struct Cluster {
+struct Cluster: Equatable {
     let center: Coordinate
     let coordinates: [Coordinate]
 }

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -27,6 +27,7 @@ struct BoundingBox {
     func contains(coordinate: Coordinate) -> Bool {
         let containsX: Bool = (bottomLeft.x <= coordinate.x) && (coordinate.x <= topRight.x)
         let containsY: Bool = (bottomLeft.y <= coordinate.y) && (coordinate.y <= topRight.y)
+        
         return (containsX && containsY)
     }
     
@@ -55,18 +56,21 @@ struct Coordinate: Equatable {
     static func + (left: Coordinate, right: Coordinate) -> Coordinate {
         let x = left.x + right.x
         let y = left.y + right.y
+        
         return Coordinate(x: x, y: y)
     }
     
     static func - (left: Coordinate, right: Coordinate) -> Coordinate {
         let x = left.x - right.x
         let y = left.y - right.y
+        
         return Coordinate(x: x, y: y)
     }
     
     static func / (left: Coordinate, right: Double) -> Coordinate {
         let x = left.x / right
         let y = left.y / right
+        
         return Coordinate(x: x, y: y)
     }
     
@@ -77,6 +81,7 @@ struct Coordinate: Equatable {
     func center(other: Coordinate) -> Coordinate {
         let centerX: Double = (self.x + other.x) / 2.0
         let centerY: Double = (self.y + other.y) / 2.0
+        
         return Coordinate(x: centerX, y: centerY)
     }
     

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -80,7 +80,7 @@ struct Coordinate: Equatable {
     
 }
 
-struct Cluster {
+struct Cluster: Equatable {
     var coordinates: [Coordinate]
     var center: Coordinate {
         coordinates.reduce(.zero, +) / Double(coordinates.count)

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -80,7 +80,7 @@ struct Coordinate: Equatable {
     
 }
 
-struct Cluster: Equatable {
+struct Cluster {
     var coordinates: [Coordinate]
     var center: Coordinate {
         coordinates.reduce(.zero, +) / Double(coordinates.count)

--- a/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/QuadTree/BoundingBox.swift
@@ -38,6 +38,8 @@ struct BoundingBox {
 
 struct Coordinate: Equatable {
     
+    static let zero = Coordinate(x: 0, y: 0)
+    
     let x: Double
     let y: Double
     
@@ -78,7 +80,12 @@ struct Coordinate: Equatable {
     
 }
 
-struct Cluster: Equatable {
-    let center: Coordinate
-    let coordinates: [Coordinate]
+struct Cluster {
+    var coordinates: [Coordinate]
+    var center: Coordinate {
+        coordinates.reduce(.zero, +) / Double(coordinates.count)
+    }
+    init(coordinates: [Coordinate]) {
+        self.coordinates = coordinates
+    }
 }

--- a/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
@@ -10,6 +10,18 @@ import XCTest
 class KDefineTests: XCTestCase {
     
     let accuracy = 0.001
+    private var avc: AverageSilhouetteCalculator?
+    private let cluster1 = Cluster(coordinates: [Coordinate(x: 1, y: 1), Coordinate(x: 2, y: 2)])
+    private var cluster2 = Cluster(coordinates: [Coordinate(x: -2, y: 1), Coordinate(x: -3, y: -2), Coordinate(x: 0, y: -2)])
+    
+    override func setUpWithError() throws {
+        let clusters = [cluster1, cluster2]
+        avc = AverageSilhouetteCalculator(clusters: clusters)
+    }
+    
+    func test_avc_init() throws {
+        XCTAssertNotNil(avc)
+    }
     
     func test_rule_of_thumb_with_5000() throws {
         let expected = 50
@@ -24,22 +36,46 @@ class KDefineTests: XCTestCase {
     }
     
     func test_find_find_cohesion() throws {
-        let cluster1 = Cluster(coordinates: [Coordinate(x: 1, y: 1), Coordinate(x: 2, y: 2)])
-        let cluster2 = Cluster(coordinates: [Coordinate(x: -2, y: 1), Coordinate(x: -3, y: -2), Coordinate(x: 0, y: -2)])
-        let clusters = [cluster1, cluster2]
-        let avc = AverageSilhouetteCalculator(clusters: clusters)
-        let result = avc.findCohesion(in: cluster1, target: cluster1.coordinates[0])
+        guard let result = avc?.findCohesion(in: cluster1, target: cluster1.coordinates[0]) else {
+            return
+        }
         let expected = sqrt(2)
         XCTAssertEqual(expected, result, accuracy: accuracy)
     }
     
     func test_find_separation() throws {
-        let cluster1 = Cluster(coordinates: [Coordinate(x: 1, y: 1), Coordinate(x: 2, y: 2)])
-        let cluster2 = Cluster(coordinates: [Coordinate(x: -2, y: 1), Coordinate(x: -3, y: -2), Coordinate(x: 0, y: -2)])
-        let clusters = [cluster1, cluster2]
-        let avc = AverageSilhouetteCalculator(clusters: clusters)
-        let result = avc.findSeparation(in: cluster1, target: cluster1.coordinates[0])
+        guard let result = avc?.findSeparation(in: cluster1, target: cluster1.coordinates[0]) else {
+            return
+        }
+        
         let expected = 3.720759
+        XCTAssertEqual(expected, result, accuracy: accuracy)
+    }
+    
+    func test_find_silhouette_A() throws {
+        guard let result = avc?.findSilhouette(with: cluster1, target: cluster1.coordinates[0]) else {
+            return
+        }
+        
+        let expected = 0.619912
+        XCTAssertEqual(expected, result, accuracy: accuracy)
+    }
+    
+    func test_find_silhouette_B() throws {
+        guard let result = avc?.findSilhouette(with: cluster1, target: cluster1.coordinates[1]) else {
+            return
+        }
+        
+        let expected = 0.717126
+        XCTAssertEqual(expected, result, accuracy: accuracy)
+    }
+    
+    func test_find_average_silhouette_cluster1() throws {
+        guard let result = avc?.findAverageSilhouette(cluster: cluster1) else {
+            return
+        }
+        
+        let expected = 0.668519
         XCTAssertEqual(expected, result, accuracy: accuracy)
     }
     

--- a/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
@@ -9,6 +9,8 @@ import XCTest
 
 class KDefineTests: XCTestCase {
     
+    let accuracy = 0.001
+    
     func test_rule_of_thumb_with_5000() throws {
         let expected = 50
         let numberOfData = 5000
@@ -22,9 +24,13 @@ class KDefineTests: XCTestCase {
     }
     
     func test_find_find_cohesion() throws {
-        let clusters = [Cluster(center: <#T##Coordinate#>, coordinates: <#T##[Coordinate]#>)]
-        let avc = AverageSilhouetteCalculator(clusters: [])
+        let cluster1 = Cluster(coordinates: [Coordinate(x: 1, y: 1), Coordinate(x: 2, y: 2)])
+        let cluster2 = Cluster(coordinates: [Coordinate(x: -2, y: 1), Coordinate(x: -3, y: -2), Coordinate(x: 0, y: -2)])
+        let clusters = [cluster1, cluster2]
+        let avc = AverageSilhouetteCalculator(clusters: clusters)
+        let result = avc.findCohesion(in: cluster1, target: cluster1.coordinates[0])
+        let expected = sqrt(2)
+        XCTAssertEqual(expected, result, accuracy: accuracy)
     }
-    
     
 }

--- a/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
@@ -11,6 +11,9 @@ class KDefineTests: XCTestCase {
     
     let accuracy = 0.001
     private var avc: AverageSilhouetteCalculator?
+    
+    /// cluster1: A(1,1), B(2,2)
+    /// cluster2: C(-2,1), D(-3,-2), D(0, -2)
     private let cluster1 = Cluster(coordinates: [Coordinate(x: 1, y: 1), Coordinate(x: 2, y: 2)])
     private var cluster2 = Cluster(coordinates: [Coordinate(x: -2, y: 1), Coordinate(x: -3, y: -2), Coordinate(x: 0, y: -2)])
     

--- a/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
@@ -33,4 +33,14 @@ class KDefineTests: XCTestCase {
         XCTAssertEqual(expected, result, accuracy: accuracy)
     }
     
+    func test_find_separation() throws {
+        let cluster1 = Cluster(coordinates: [Coordinate(x: 1, y: 1), Coordinate(x: 2, y: 2)])
+        let cluster2 = Cluster(coordinates: [Coordinate(x: -2, y: 1), Coordinate(x: -3, y: -2), Coordinate(x: 0, y: -2)])
+        let clusters = [cluster1, cluster2]
+        let avc = AverageSilhouetteCalculator(clusters: clusters)
+        let result = avc.findSeparation(in: cluster1, target: cluster1.coordinates[0])
+        let expected = 3.720759
+        XCTAssertEqual(expected, result, accuracy: accuracy)
+    }
+    
 }

--- a/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
@@ -38,16 +38,16 @@ class KDefineTests: XCTestCase {
         XCTAssertEqual(KwithRuleOfThumb(numberOfData: numberOfData), expected)
     }
     
-    func test_find_find_cohesion() throws {
-        guard let result = avc?.findCohesion(in: cluster1, target: cluster1.coordinates[0]) else {
+    func test_calculate_cohesion() throws {
+        guard let result = avc?.calculateCohesion(in: cluster1, target: cluster1.coordinates[0]) else {
             return
         }
         let expected = sqrt(2)
         XCTAssertEqual(expected, result, accuracy: accuracy)
     }
     
-    func test_find_separation() throws {
-        guard let result = avc?.findSeparation(in: cluster1, target: cluster1.coordinates[0]) else {
+    func test_calculate_separation() throws {
+        guard let result = avc?.calculateSeparation(in: cluster1, target: cluster1.coordinates[0]) else {
             return
         }
         
@@ -55,8 +55,8 @@ class KDefineTests: XCTestCase {
         XCTAssertEqual(expected, result, accuracy: accuracy)
     }
     
-    func test_find_silhouette_A() throws {
-        guard let result = avc?.findSilhouette(with: cluster1, target: cluster1.coordinates[0]) else {
+    func test_calculate_silhouette_A() throws {
+        guard let result = avc?.calculateSilhouette(with: cluster1, target: cluster1.coordinates[0]) else {
             return
         }
         
@@ -64,8 +64,8 @@ class KDefineTests: XCTestCase {
         XCTAssertEqual(expected, result, accuracy: accuracy)
     }
     
-    func test_find_silhouette_B() throws {
-        guard let result = avc?.findSilhouette(with: cluster1, target: cluster1.coordinates[1]) else {
+    func test_calculate_silhouette_B() throws {
+        guard let result = avc?.calculateSilhouette(with: cluster1, target: cluster1.coordinates[1]) else {
             return
         }
         
@@ -73,8 +73,8 @@ class KDefineTests: XCTestCase {
         XCTAssertEqual(expected, result, accuracy: accuracy)
     }
     
-    func test_find_average_silhouette_cluster1() throws {
-        guard let result = avc?.findAverageSilhouette(cluster: cluster1) else {
+    func test_calculate_average_silhouette_cluster1() throws {
+        guard let result = avc?.calculateAverageSilhouette(cluster: cluster1) else {
             return
         }
         

--- a/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
@@ -1,0 +1,14 @@
+//
+//  KDefineTests.swift
+//  InteractiveClusteringMapTests
+//
+//  Created by A on 2020/11/25.
+//
+
+import XCTest
+
+class KDefineTests: XCTestCase {
+
+    
+
+}

--- a/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
@@ -7,18 +7,24 @@
 
 import XCTest
 
-    class KDefineTests: XCTestCase {
-
-    func test_RuleOfThumb_with_5000() throws {
+class KDefineTests: XCTestCase {
+    
+    func test_rule_of_thumb_with_5000() throws {
         let expected = 50
         let numberOfData = 5000
         XCTAssertEqual(KwithRuleOfThumb(numberOfData: numberOfData), expected)
     }
     
-    func test_RuleOfThumb_with_8000() throws {
+    func test_rule_of_thumb_with_8000() throws {
         let expected = 63
         let numberOfData = 8000
         XCTAssertEqual(KwithRuleOfThumb(numberOfData: numberOfData), expected)
     }
-
+    
+    func test_find_find_cohesion() throws {
+        let clusters = [Cluster(center: <#T##Coordinate#>, coordinates: <#T##[Coordinate]#>)]
+        let avc = AverageSilhouetteCalculator(clusters: [])
+    }
+    
+    
 }

--- a/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/KDefineTests.swift
@@ -7,8 +7,18 @@
 
 import XCTest
 
-class KDefineTests: XCTestCase {
+    class KDefineTests: XCTestCase {
 
+    func test_RuleOfThumb_with_5000() throws {
+        let expected = 50
+        let numberOfData = 5000
+        XCTAssertEqual(KwithRuleOfThumb(numberOfData: numberOfData), expected)
+    }
     
+    func test_RuleOfThumb_with_8000() throws {
+        let expected = 63
+        let numberOfData = 8000
+        XCTAssertEqual(KwithRuleOfThumb(numberOfData: numberOfData), expected)
+    }
 
 }


### PR DESCRIPTION
## 구현내용
### [feat] [test]
* k 결정 방법 Rule of Thumb 구현
* k 검증 - Average Silhouette Calculator 클래스 구현 
* 테스트 함수 작성

### Silhouette Method
<img width="327" alt="스크린샷 2020-11-26 오후 5 11 12" src="https://user-images.githubusercontent.com/62557093/100324299-63f8fb80-300a-11eb-8bc6-117387ed2076.png"/>
현재 클러스터의 응집도와 다른 클러스터 간의 결합도를 정량적으로 판단하여 클러스터링이 잘 되었는지 판단하는 방법
<br><br>
i번째 데이터에 대하여  <br><br>
 a(i) :  같은 클러스터 안에 있는 다른 데이터 포인트와의 평균거리(dissimilarity).    <br><br>
 b(i) :  i가 속하지 않은 다른 클러스터와의 평균 거리 중 가장 작은 거리 <br><br>


- **해석**
1.  b가 a보다 많이 클수록 1에 가까워지고 좋다.
2.  0이면 지금 클러스터나 이웃 클러스터나 어디 있든 상관 없다.
3.  silhouette는 -1 부터 1 사이의 값을 가진다 → **1**일수록 잘 부합하는 거고, **-1**일수록 잘못 뭉쳐져 있다는 뜻


## 논의사항
rule of thumb와 silhouette 검증 방법을 결합해서 적절한 K 값을 구하는 방법을 사용하면 좋을 것 같은데,
어떻게 결합할지 논의해 보면 좋겠어요!
많은 피드백 부탁드립니다🙇🏻‍♀️

### 화면 
<img width="243" alt="스크린샷 2020-11-26 오후 4 56 41" src="https://user-images.githubusercontent.com/62557093/100325210-a8d16200-300b-11eb-8626-075b5eec1208.png">



