### PR TITLE
지도에 지워져야 할 마커 사라지지 않는 문제 해결

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap/Map/MapController.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/MapController.swift
@@ -13,6 +13,7 @@ final class MapController: NSObject {
     private var tileCoverHelper: NMFTileCoverHelper?
     private var interactor: ClusterBusinessLogic?
     private weak var interactiveMapView: InteractiveMapView?
+    private let serialQueue = DispatchQueue(label: QueueName.serial)
     
     init(mapView: InteractiveMapView, interactor: ClusterBusinessLogic) {
         self.interactiveMapView = mapView
@@ -35,24 +36,23 @@ extension MapController: NMFTileCoverHelperDelegate {
     func onTileChanged(_ addedTileIds: [NSNumber]?, removedTileIds: [NSNumber]?) {
         guard let addedTiles = addedTileIds as? [CLong],
               let removedTiles = removedTileIds as? [CLong] else { return }
-        
-        interactor?.remove(tileIds: removedTiles)
-        
-        var boundsWithTileId = [CLong: BoundingBox]()
-        addedTiles.forEach { tileId in
-            let bounds = NMFTileId.toLatLngBounds(fromTileId: tileId)
-            let BL = bounds.boundsLatLngs[Index.BL]
-            let TR = bounds.boundsLatLngs[Index.TR]
+
+        serialQueue.async {
+            self.interactor?.remove(tileIds: removedTiles)
+            var boundsWithTileId = [CLong: BoundingBox]()
+            addedTiles.forEach { tileId in
+                let bounds = NMFTileId.toLatLngBounds(fromTileId: tileId)
+                let BL = bounds.boundsLatLngs[Index.BL]
+                let TR = bounds.boundsLatLngs[Index.TR]
+                
+                let bottomLeft = Coordinate(x: BL.lng, y: BL.lat)
+                let topRight = Coordinate(x: TR.lng, y: TR.lat)
+                boundsWithTileId[tileId] = BoundingBox(topRight: topRight, bottomLeft: bottomLeft)
+            }
             
-            let bottomLeft = Coordinate(x: BL.lng, y: BL.lat)
-            let topRight = Coordinate(x: TR.lng, y: TR.lat)
-            
-            boundsWithTileId[tileId] = BoundingBox(topRight: topRight, bottomLeft: bottomLeft)
+            guard let interactiveMapView = self.interactiveMapView else { return }
+            self.interactor?.fetch(boundingBoxes: boundsWithTileId, zoomLevel: interactiveMapView.zoomLevel)
         }
-        
-        guard let interactiveMapView = interactiveMapView else { return }
-        
-        interactor?.fetch(boundingBoxes: boundsWithTileId, zoomLevel: interactiveMapView.zoomLevel)
     }
     
 }
@@ -62,6 +62,10 @@ private extension MapController {
     enum Index {
         static let BL: Int = 0
         static let TR: Int = 1
+    }
+    
+    enum QueueName {
+        static let serial: String = "MapController.TileChangedEventQueue"
     }
     
 }

--- a/Project17-C-Map/InteractiveClusteringMap/Map/MapInteractor.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/MapInteractor.swift
@@ -17,7 +17,7 @@ final class MapInteractor: ClusterBusinessLogic {
     
     private let poiService: POIServicing
     private let presenter: ClusterPresentationLogic
-    private var clusteringServicing: QuadTreeClusteringService?
+    private var clusteringService: ClusteringServicing?
     
     init(poiService: POIServicing, presenter: ClusterPresentationLogic) {
         self.poiService = poiService
@@ -32,16 +32,14 @@ final class MapInteractor: ClusterBusinessLogic {
                 let coordinates = pois.map {
                     Coordinate(x: $0.x, y: $0.y)
                 }
-                if self.clusteringServicing == nil {
-                    self.clusteringServicing = QuadTreeClusteringService(coordinates: coordinates,
+                if self.clusteringService == nil {
+                    self.clusteringService = QuadTreeClusteringService(coordinates: coordinates,
                                                                          boundingBox: BoundingBox.korea)
                 }
-                DispatchQueue.global(qos: .userInitiated).async {
-                    self.clustering(coordinates: coordinates,
-                                    tileId: tileId,
-                                    boundingBox: boundingBox,
-                                    zoomLevel: zoomLevel)
-                }
+                self.clustering(coordinates: coordinates,
+                                tileId: tileId,
+                                boundingBox: boundingBox,
+                                zoomLevel: zoomLevel)
             }
         }
     }
@@ -55,11 +53,11 @@ final class MapInteractor: ClusterBusinessLogic {
                             boundingBox: BoundingBox,
                             zoomLevel: Double) {
         
-        clusteringServicing?.execute(coordinates: coordinates,
+        clusteringService?.execute(coordinates: coordinates,
                                      boundingBox: boundingBox,
                                      zoomLevel: zoomLevel) { [weak self] clusters in
             guard let self = self else { return }
-                                                            
+                                      
             self.presenter.clustersToMarkers(tileId: tileId, clusters: clusters)
         }
     }

--- a/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
@@ -15,6 +15,7 @@ final class MapViewController: UIViewController {
     private let locationManager = CLLocationManager()
     private var mapController: MapController?
     private var dataManager: DataManagable?
+    private var deletedinteractiveMarkers: [InteractiveMarker] = []
     
     init?(coder: NSCoder, dataManager: DataManagable) {
         self.dataManager = dataManager
@@ -58,6 +59,12 @@ final class MapViewController: UIViewController {
     }
     
     private func createMarkers(interactiveMarkers: [InteractiveMarker]) {
+        deletedinteractiveMarkers.forEach { interactiveMarker in
+            DispatchQueue.main.async {
+                interactiveMarker.mapView = nil
+                self.deletedinteractiveMarkers.removeAll { $0 == interactiveMarker }
+            }
+        }
         interactiveMarkers.forEach { interactiveMarker in
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
@@ -67,11 +74,7 @@ final class MapViewController: UIViewController {
     }
     
     private func removeMarkers(interactiveMarkers: [InteractiveMarker]) {
-        interactiveMarkers.forEach { interactiveMarker in
-            DispatchQueue.main.async {
-                interactiveMarker.mapView = nil
-            }
-        }
+        deletedinteractiveMarkers += interactiveMarkers
     }
     
 }

--- a/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
@@ -11,7 +11,7 @@ import NMapsMap
 
 final class MapViewController: UIViewController {
 
-    @IBOutlet weak var interactiveMapView: InteractiveMapView!
+    @IBOutlet private weak var interactiveMapView: InteractiveMapView!
     private let locationManager = CLLocationManager()
     private var mapController: MapController?
     private var dataManager: DataManagable?


### PR DESCRIPTION
## 구현내용
### [fix], [clustering]
* 삭제되지 못한 TileId들을 배열로 들고 있고, 다음에 마커를 그려주는 부분에서 
배열에 포함되어있으면 그리지 않는 방식으로 해결

## 논의사항
지금은 onTileChanged에서 직렬 비동기 큐에 remove, fetch 작업을 넣어주고,
fetch에서 클러스터링 작업을 다른 직렬 비동기 큐에 넣어줍니다. 
클러스터링 직렬 이유 : 트리 안에서 insert가 끝나고 클러스터링이 처리되야하기 때문

병렬 큐를 사용해서 속도를 더 내보고 싶은데 여러 의견 나누어 주세요 ~~! 
(트리안에 insert 작업이 끝나고 클러스터링 되는 것을 보장하기 위해 직렬큐 말고 어떻게 할 수 있을지 ..?)

또 presenter 내부의 dictionary를 전역으로 두고 처리하면 순수 객체가 아니라서 SideEffect가 발생해서 문제가 났던건데
이부분을 혹시 순수 객체로 변경해서 사용할 수 있는 방법을 아시는 분은 의견 나눠주세요 ~~~ ㅎㅎㅎㅎ