### PR TITLE
코드 리팩토링 및 개선 시도

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap/CoreData/POIService.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/CoreData/POIService.swift
@@ -12,11 +12,6 @@ protocol POIServicing {
     func add(poi: POI)
     func update(poi: POI)
     func delete(coordinate: Coordinate)
-    func fetch() -> [Coordinate]
-    func fetch(completion: @escaping ([Coordinate]) -> Void)
-    func fetch(coordinate: Coordinate) -> [POI]
-    func fetch(coordiante: Coordinate, completion: @escaping ([POI]) -> Void)
-    func fetch(bottomLeft: Coordinate, topRight: Coordinate) -> [Coordinate]
     func fetch(bottomLeft: Coordinate, topRight: Coordinate, completion: @escaping ([Coordinate]) -> Void)
     func save()
     
@@ -25,6 +20,7 @@ protocol POIServicing {
 final class POIService: POIServicing {
     
     private let dataManager: DataManagable
+    private var coordinates: [Coordinate] = []
     
     init(dataManager: DataManagable) {
         self.dataManager = dataManager
@@ -42,41 +38,14 @@ final class POIService: POIServicing {
         dataManager.delete(coordinate: coordinate)
     }
     
-    func fetch() -> [Coordinate] {
-        let pois = dataManager.fetch()
-        return pois.map { $0.coordinate }
-    }
-    
-    func fetch(completion: @escaping ([Coordinate]) -> Void) {
-        dataManager.fetch {
-            completion($0.map { $0.coordinate })
-        }
-    }
-    
-    func fetch(coordinate: Coordinate) -> [POI] {
-        let pois = dataManager.fetch(coordinate: coordinate)
-        return pois.compactMap { $0.poi }
-    }
-    
-    func fetch(coordiante: Coordinate, completion: @escaping ([POI]) -> Void) {
-        dataManager.fetch(coordinate: coordiante) {
-            completion($0.compactMap { $0.poi })
-        }
-    }
-    
-    func fetch(bottomLeft: Coordinate, topRight: Coordinate) -> [Coordinate] {
-        let pois = dataManager.fetch(bottomLeft: bottomLeft, topRight: topRight)
-        return pois.map { $0.coordinate }
+    func save() {
+        dataManager.save(successHandler: nil, failureHandler: nil)
     }
     
     func fetch(bottomLeft: Coordinate, topRight: Coordinate, completion: @escaping ([Coordinate]) -> Void) {
         dataManager.fetch(bottomLeft: bottomLeft, topRight: topRight) {
             completion($0.map { $0.coordinate })
         }
-    }
-    
-    func save() {
-        dataManager.save(successHandler: nil, failureHandler: nil)
     }
     
 }

--- a/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
@@ -9,15 +9,6 @@ import UIKit
 import CoreLocation
 import NMapsMap
 
-// 다음 PR에 Tree 객체 저장하고 불러오는 기능 프로토콜 추가 예정
-protocol TreeServicing {
-    
-}
-
-struct MockTreeService: TreeServicing {
-    
-}
-
 final class MapViewController: UIViewController {
     @IBOutlet private weak var interactiveMapView: InteractiveMapView!
     private let locationManager = CLLocationManager()
@@ -50,9 +41,7 @@ final class MapViewController: UIViewController {
         guard let dataManager = dataManager else { return }
         
         let poiService = POIService(dataManager: dataManager)
-        let treeService = MockTreeService()
-        let treeDataStore = TreeDataStore(poiService: poiService, treeService: treeService)
-        
+        let treeDataStore = TreeDataStore(poiService: poiService)
         let presenter: ClusterPresentationLogic = MapPresenter(createMarkerHandler: create, removeMarkerHandler: remove)
         let mapInteractor: ClusterBusinessLogic = MapInteractor(treeDataStore: treeDataStore, presenter: presenter)
         mapController = MapController(mapView: interactiveMapView, interactor: mapInteractor)


### PR DESCRIPTION
## 구현내용
### [refac]
사용하지않은 코드 삭제 및 코드 일부 리팩토링

210만개 데이터를 기준으로 속도 개선을 하고자  다양한 방법을 시도

## 논의사항
1.  기존의 분할한 영역만큼 NSPredicate을 여러번 요청하여 fetch하는 방법에서 전체 Coordinate 데이터를 한번에 fetch하여 filter하는 방법과 
속도를 비교
```
func performQuery(topRight: Coordinate, bottomLeft: Coordinate) -> [Coordinate] {
    return coordinates.filter {
        $0.x >= bottomLeft.x && $0.x < topRight.x &&
            $0.y >= bottomLeft.y && $0.y < topRight.y
    }
}
```
> 속도 개선의 영향을 주지 못함. 😭

2.  전체 데이터를 백그라운드에서 fetch 후 사용하려 했으나, 트리가 병렬로 생성되면서 사이드 이펙트 발생.
> 사이드 이펙트 방지를 위해 fetch 완료 후, 트리를 생성했지만 기존 로직과 비슷하면서 안정성이나 속도가 더 느림. 😱

3.  처음 앱 실행 시, 생성된 트리를 Json 데이터로 변환하여 파일로 저장 후 다음 실행 시 저장된 Json 데이터를 사용하여 트리를 재사용하고자 함.
> 데이터를 읽고, Decode하는 과정이 트리를 생성하는 시간보다 느림. 😡

4.  처음 앱 실행 시, 생성된 트리를 아카이브하여 UserDefault에 저장 후  재사용하고자 함.
> 데이터를 읽고, unarchive / decode 하는 과정이 트리를 생성하는 시간보다 느림. ☠️

**결론**
생각보다 트리 만드는 속도가 빨랐다...

------------------------
**혹시 다른 좋은 방법이 있으신분은 댓글을 꼭 좀 부탁드리겠습니다.**
