### PR TITLE
Quad tree remove 구현, QuadTreeServiceTests 수정

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap/Clustering/QuadTree/QuadTree.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Clustering/QuadTree/QuadTree.swift
@@ -80,6 +80,19 @@ final class QuadTree {
         return false
     }
     
+    func remove(coordinate: Coordinate) {
+        guard boundingBox.contains(coordinate: coordinate) else { return }
+        
+        if coordinates.contains(coordinate) {
+            coordinates.removeAll { $0 == coordinate }
+            return
+        }
+        topLeft?.remove(coordinate: coordinate)
+        topRight?.remove(coordinate: coordinate)
+        bottomLeft?.remove(coordinate: coordinate)
+        bottomRight?.remove(coordinate: coordinate)
+    }
+    
     // 모든 Coordinate가 insert 되면 외부에서 한번 호출 -> 자식까지 모두 BoundingBox 조절
     func updateBoundingBox(topRight: Coordinate? = nil, bottomLeft: Coordinate? = nil) {
         let topRightCoordinate = topRight ?? Coordinate(x: maxX, y: maxY)

--- a/Project17-C-Map/InteractiveClusteringMap/Map/TreeDataStore.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/TreeDataStore.swift
@@ -9,6 +9,8 @@ import Foundation
 
 protocol TreeDataStorable {
     func quadTrees(target: BoundingBox) -> [QuadTree]
+    func remove(coordinate: Coordinate)
+    func add(coordinate: Coordinate)
 }
 
 class TreeDataStore: TreeDataStorable {
@@ -27,6 +29,18 @@ class TreeDataStore: TreeDataStorable {
     //target에 속한 쿼드트리를 찾아서 반환한다.
     func quadTrees(target: BoundingBox) -> [QuadTree] {
         return quadTreeWithBoundary.filter { $0.key.isOverlapped(with: target) }.map {$0.value}
+    }
+    
+    func remove(coordinate: Coordinate) {
+        let trees = quadTreeWithBoundary.filter { $0.key.contains(coordinate: coordinate) }
+        trees.forEach {
+            $0.value.remove(coordinate: coordinate)
+        }
+    }
+    
+    func add(coordinate: Coordinate) {
+        let trees = quadTreeWithBoundary.filter { $0.key.contains(coordinate: coordinate) }
+        trees.first?.value.insert(coordinate: coordinate)
     }
     
     private func makeQuadTrees() {

--- a/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/QuadTreeServiceTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/QuadTreeServiceTests.swift
@@ -7,6 +7,16 @@
 
 import XCTest
 
+struct MockupDataStore: TreeDataStorable {
+    
+    func quadTrees(target: BoundingBox) -> [QuadTree] {
+        [Mockup().mockupQuadTree()]
+    }
+    func remove(coordinate: Coordinate) {}
+    func add(coordinate: Coordinate) {}
+ 
+}
+
 class QuadTreeServiceTests: XCTestCase {
     
     private let coordinates = [
@@ -21,8 +31,8 @@ class QuadTreeServiceTests: XCTestCase {
     private var quadTreeClusteringService: QuadTreeClusteringService?
     
     override func setUpWithError() throws {
-        quadTreeClusteringService = QuadTreeClusteringService(coordinates: coordinates,
-                                                              boundingBox: boundingBox)
+        let dataStore = MockupDataStore()
+        quadTreeClusteringService = QuadTreeClusteringService(treeDataStore: dataStore)
     }
     
     func test_QuadTreeClusteringService_init() {

--- a/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/QuadTreeTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/QuadTreeTests.swift
@@ -70,6 +70,67 @@ class QuadTreeTests: XCTestCase {
         testQuadTreeFindCoordinates(region: region, expectedCoordinates: expectedCoordinates)
     }
     
+    func test_QuadTree_remove_x_1_y_1() {
+        quadTree?.remove(coordinate: coordinates[0])
+        let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
+        
+        let expectedCoornates = [
+            Coordinate(x: 2, y: 2),
+            Coordinate(x: 3, y: 3),
+            Coordinate(x: 6, y: 6)
+        ]
+        XCTAssertEqual(foundCoordinates, expectedCoornates)
+    }
+    
+    func test_QuadTree_remove_x_2_y_2() {
+        quadTree?.remove(coordinate: coordinates[1])
+        let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
+        
+        let expectedCoornates = [
+            Coordinate(x: 1, y: 1),
+            Coordinate(x: 3, y: 3),
+            Coordinate(x: 6, y: 6)
+        ]
+        XCTAssertEqual(foundCoordinates, expectedCoornates)
+    }
+    
+    func test_QuadTree_remove_x_3_y_3() {
+        quadTree?.remove(coordinate: coordinates[2])
+        let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
+        
+        let expectedCoornates = [
+            Coordinate(x: 1, y: 1),
+            Coordinate(x: 2, y: 2),
+            Coordinate(x: 6, y: 6)
+        ]
+        XCTAssertEqual(foundCoordinates, expectedCoornates)
+    }
+    
+    func test_QuadTree_remove_x_6_y_6() {
+        quadTree?.remove(coordinate: coordinates[3])
+        let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
+        
+        let expectedCoornates = [
+            Coordinate(x: 1, y: 1),
+            Coordinate(x: 2, y: 2),
+            Coordinate(x: 3, y: 3)
+        ]
+        XCTAssertEqual(foundCoordinates, expectedCoornates)
+    }
+    
+    func test_QuadTree_remove_not_contains() {
+        quadTree?.remove(coordinate: Coordinate(x: 4, y: 4))
+        let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
+        
+        let expectedCoornates = [
+            Coordinate(x: 1, y: 1),
+            Coordinate(x: 2, y: 2),
+            Coordinate(x: 3, y: 3),
+            Coordinate(x: 6, y: 6)
+        ]
+        XCTAssertEqual(foundCoordinates, expectedCoornates)
+    }
+    
     private func testQuadTreeFindCoordinates(region: BoundingBox, expectedCoordinates: [Coordinate]) {
         let findCoordinates = quadTree?.findCoordinates(
             region: region)

--- a/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/QuadTreeTests.swift
+++ b/Project17-C-Map/InteractiveClusteringMapTests/QuadTreeTests/QuadTreeTests.swift
@@ -74,61 +74,61 @@ class QuadTreeTests: XCTestCase {
         quadTree?.remove(coordinate: coordinates[0])
         let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
         
-        let expectedCoornates = [
+        let expectedCoordinates = [
             Coordinate(x: 2, y: 2),
             Coordinate(x: 3, y: 3),
             Coordinate(x: 6, y: 6)
         ]
-        XCTAssertEqual(foundCoordinates, expectedCoornates)
+        XCTAssertEqual(foundCoordinates, expectedCoordinates)
     }
     
     func test_QuadTree_remove_x_2_y_2() {
         quadTree?.remove(coordinate: coordinates[1])
         let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
         
-        let expectedCoornates = [
+        let expectedCoordinates = [
             Coordinate(x: 1, y: 1),
             Coordinate(x: 3, y: 3),
             Coordinate(x: 6, y: 6)
         ]
-        XCTAssertEqual(foundCoordinates, expectedCoornates)
+        XCTAssertEqual(foundCoordinates, expectedCoordinates)
     }
     
     func test_QuadTree_remove_x_3_y_3() {
         quadTree?.remove(coordinate: coordinates[2])
         let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
         
-        let expectedCoornates = [
+        let expectedCoordinates = [
             Coordinate(x: 1, y: 1),
             Coordinate(x: 2, y: 2),
             Coordinate(x: 6, y: 6)
         ]
-        XCTAssertEqual(foundCoordinates, expectedCoornates)
+        XCTAssertEqual(foundCoordinates, expectedCoordinates)
     }
     
     func test_QuadTree_remove_x_6_y_6() {
         quadTree?.remove(coordinate: coordinates[3])
         let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
         
-        let expectedCoornates = [
+        let expectedCoordinates = [
             Coordinate(x: 1, y: 1),
             Coordinate(x: 2, y: 2),
             Coordinate(x: 3, y: 3)
         ]
-        XCTAssertEqual(foundCoordinates, expectedCoornates)
+        XCTAssertEqual(foundCoordinates, expectedCoordinates)
     }
     
     func test_QuadTree_remove_not_contains() {
         quadTree?.remove(coordinate: Coordinate(x: 4, y: 4))
         let foundCoordinates = quadTree?.findCoordinates(region: boundingBox)
         
-        let expectedCoornates = [
+        let expectedCoordinates = [
             Coordinate(x: 1, y: 1),
             Coordinate(x: 2, y: 2),
             Coordinate(x: 3, y: 3),
             Coordinate(x: 6, y: 6)
         ]
-        XCTAssertEqual(foundCoordinates, expectedCoornates)
+        XCTAssertEqual(foundCoordinates, expectedCoordinates)
     }
     
     private func testQuadTreeFindCoordinates(region: BoundingBox, expectedCoordinates: [Coordinate]) {


### PR DESCRIPTION
## 구현내용
### [feat], [test]
* QuadTree에 remove 기능 구현, 테스트

* TreeDataStore에 add, remove 기능 추가
  > Interactor에서 TreeDataStore 이용해서 추가, 삭제하면 됨

* QuadTreeClusteringService 변경 된 구조에 맞게 테스트 수정
