### PR TITLE
마커 삭제 시 layer 가 그대로 남아있던 버그 수정

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap/Map/MapPresenter.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/MapPresenter.swift
@@ -87,6 +87,7 @@ class MapPresenter: ClusterPresentationLogic {
                     leafMarker.mapView = nil
                     return false
                 }
+                
                 return true
             }
         }

--- a/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
@@ -81,7 +81,7 @@ final class MapViewController: UIViewController {
         guard let touch = touches.first else { return }
         let point = touch.location(in: interactiveMapView.mapView)
         
-        for marker in presentedMarkers {
+        for (index, marker) in presentedMarkers.enumerated() {
             guard let leafMarker = marker as? LeafNodeMarker else { continue }
             
             let editButtonRange = interactiveMapView.projectPoint(from: NMGLatLng(lat: leafMarker.coordinate.y, lng: leafMarker.coordinate.x))
@@ -94,7 +94,11 @@ final class MapViewController: UIViewController {
             if containX && containY {
                 touchedDeleteLayer = true
                 let alert = MapAlertController(alertType: .delete, okHandler: { [weak self] (_) in
+                    leafMarker.mapView = nil
+                    leafMarker.markerLayer.removeFromSuperlayer()
+                    self?.presentedMarkers.remove(at: index)
                     self?.mapController?.delete(coordinate: leafMarker.coordinate)
+                    
                     self?.touchedDeleteLayer = false
                 }, cancelHandler: { [weak self] (_) in
                     guard let self = self else { return }
@@ -106,7 +110,7 @@ final class MapViewController: UIViewController {
     }
     
     @objc func handleLongPress(gesture: UILongPressGestureRecognizer) {
-        guard gesture.state != .began else {
+        guard gesture.state != .began && !isEditMode else {
             return
         }
         if isMarkerLongPressed(gesture: gesture) {
@@ -132,7 +136,6 @@ final class MapViewController: UIViewController {
                     
                     return true
                 }
-            } else {
             }
         }
         return false
@@ -144,7 +147,7 @@ final class MapViewController: UIViewController {
         presentedMarkers.forEach { marker in
             guard let marker = marker as? LeafNodeMarker else { return }
             marker.hidden = true
-            let leafNodeMarkerLayer = LeafNodeMarkerLayer(markerID: marker.coordinate.id)
+            let leafNodeMarkerLayer = marker.markerLayer
             leafNodeMarkerLayer.bounds = CGRect(x: 0, y: 0,
                                                 width: marker.iconImage.imageWidth,
                                                 height: marker.iconImage.imageHeight)

--- a/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
@@ -93,16 +93,15 @@ final class MapViewController: UIViewController {
             
             if containX && containY {
                 touchedDeleteLayer = true
-                let alert = MapAlertController(alertType: .delete, okHandler: { [weak self] (_) in
+                let alert = MapAlertController(alertType: .delete, okHandler: { [weak self] _ in
                     leafMarker.mapView = nil
                     leafMarker.markerLayer.removeFromSuperlayer()
                     self?.presentedMarkers.remove(at: index)
                     self?.mapController?.delete(coordinate: leafMarker.coordinate)
                     
                     self?.touchedDeleteLayer = false
-                }, cancelHandler: { [weak self] (_) in
-                    guard let self = self else { return }
-                    self.touchedDeleteLayer = false
+                }, cancelHandler: { [weak self] _ in
+                    self?.touchedDeleteLayer = false
                 })
                 present(alert.createAlertController(), animated: true)
             }


### PR DESCRIPTION
## 구현내용
### [fix]
- edit 모드 시 누른 상태로 손가락을 움직이면 layer가 중첩하여 생기는 버그 수정
- 삭제 시 layer가 지워지지 않는 버그 수정
- 같은 화면에서 edit 모드로 들어가면 이전에 지웠던 마커가 보이는 버그 수정

### 화면
![Dec-08-2020 18-55-14](https://user-images.githubusercontent.com/18098363/101468560-ef697980-3986-11eb-9804-15931c416275.gif)
