### PR TITLE
[fix] 최상단에서 애니메이션이 계속되던 버그 수정

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap/Map/InteractiveMapView.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/InteractiveMapView.swift
@@ -35,6 +35,7 @@ final class InteractiveMapView: NMFNaverMapView {
         showCompass = true
         showScaleBar = true
         mapView.allowsTilting = false
+        mapView.minZoomLevel = 2
         
         configureExtent()
     }

--- a/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/MapViewController.swift
@@ -273,7 +273,6 @@ final class MapViewController: UIViewController {
             marker.hidden = true
             CATransaction.setCompletionBlock {
                 markerLayer.removeFromSuperlayer()
-                marker.hidden = false
             }
             markerLayer.add(markerAnimation, forKey: "dismissMarker")
             CATransaction.commit()


### PR DESCRIPTION
## 구현내용
### [fix] 
- 최상단에서 onTileChange 시에 addedTile만 들어오고 removed Tile이 들어오지 않아서 계속 같은 타일을 클러스터링 하여 계속 마커가 찍히는 문제였음
-> 실제로 한반도 기준으로 서비스를 할 것이므로 최소 줌레벨을 2로 지정
- interactive marker 클릭 애니메이션시 마지막에 마커가 잠깐 다시 뜨는 문제 수정
-> 애니메이션 끝나는 부분에 marker.hidden false 부분 삭제