### PR TITLE
[fix] marker infowindow constraint 수정

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap/Map/CustomInfoWindow.xib
+++ b/Project17-C-Map/InteractiveClusteringMap/Map/CustomInfoWindow.xib
@@ -34,16 +34,16 @@
                     </constraints>
                 </imageView>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="imgInfowindow13" translatesAutoresizingMaskIntoConstraints="NO" id="f16-B7-6HG">
-                    <rect key="frame" x="160" y="11" width="110" height="100"/>
+                    <rect key="frame" x="160" y="11" width="30" height="100"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="100" id="BBS-jn-5UO"/>
-                        <constraint firstAttribute="width" constant="110" id="Wm6-Qw-gEf"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="Wm6-Qw-gEf"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="여기는 카테고리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pGH-yI-kfA">
-                    <rect key="frame" x="31" y="54.5" width="255" height="17"/>
+                    <rect key="frame" x="31" y="54.5" width="175" height="17"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                    <color key="textColor" systemColor="systemGrayColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="여기는 장소 이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GMb-lm-Ykj">
@@ -57,7 +57,7 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="pGH-yI-kfA" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="f16-B7-6HG" secondAttribute="trailing" constant="16" id="1JN-Jv-vI8"/>
-                <constraint firstItem="f16-B7-6HG" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="GMb-lm-Ykj" secondAttribute="trailing" constant="16" id="8el-sO-Cdl"/>
+                <constraint firstItem="f16-B7-6HG" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="GMb-lm-Ykj" secondAttribute="trailing" constant="20" id="8el-sO-Cdl"/>
                 <constraint firstItem="pGH-yI-kfA" firstAttribute="leading" secondItem="GMb-lm-Ykj" secondAttribute="leading" id="AQm-K6-u2D"/>
                 <constraint firstItem="f16-B7-6HG" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="11" id="EaK-fY-t32"/>
                 <constraint firstItem="NcR-Bl-lUT" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="10" id="PF0-R9-nvO"/>
@@ -77,8 +77,8 @@
         <image name="imgInfowindow11" width="24" height="88"/>
         <image name="imgInfowindow12" width="30" height="88"/>
         <image name="imgInfowindow13" width="27" height="88"/>
-        <systemColor name="secondaryLabelColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
## 구현내용
### [fix]
- marker info window의 constraint 수정
- 카테고리 설명 글씨 색상 gray로 변경

### 화면 
<img src ="https://user-images.githubusercontent.com/33716159/102011746-a0a65000-3d89-11eb-9ff7-c1f5f01724ea.jpeg" width=300>
