### PR TITLE
[fix] Core data stack init 시 fetch -> count 로 변경

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap/CoreData/CoreDataStack.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/CoreData/CoreDataStack.swift
@@ -24,8 +24,8 @@ final class CoreDataStack: DataManagable {
     private init() {
         context.parent = container?.viewContext
         
-        guard let pois = try? context.fetch(POIMO.fetchRequest()),
-              pois.count != 0 else {
+        guard let poiCount = try? container?.viewContext.count(for: POIMO.fetchRequest()),
+              poiCount != 0 else {
             let pois = JSONReader.readPOIs(fileName: Name.fileName)
             pois?.forEach {
                 setValue($0)


### PR DESCRIPTION
## 구현내용
### [fix]
현재 CoreDataStack init 시 모든 데이터를 fetch 해온 후 count가 없는 경우 json에서 불러오도록 하였는데,
count 만 가져오도록 변경