### PR TITLE
Core data persistent store 에러 핸들링 처리

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap/AppDelegate.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/AppDelegate.swift
@@ -25,24 +25,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-
+        
     }
     
     // MARK: - Core Data Stack
     
     lazy var container: NSPersistentContainer = {
         let container = NSPersistentContainer(name: containerName)
-        container.loadPersistentStores(completionHandler: { (_, error) in
-            if let error = error as NSError? {
-                print(error.localizedDescription)
+        container.loadPersistentStores(completionHandler: { (description, error) in
+            guard error == nil else {
+                fatalError("NSPersistentStores load failure: \(error.debugDescription)")
             }
-            
-            let description = NSPersistentStoreDescription()
             description.shouldMigrateStoreAutomatically = true
             description.shouldInferMappingModelAutomatically = true
             container.persistentStoreDescriptions = [description]
-            
         })
+        
         return container
     }()
     


### PR DESCRIPTION
구현내용

[feat]
persistent store를 로드 시 error를 반환하는 경우는 migration과 같은 개발자가 해결해야 할 error 반환
-> 일부러 fatalError를 실행하여 개발자에게 error 발생을 알려주도록 수정