### PR TITLE
core data json data init 비동기로 처리

### DIFF
--- a/Project17-C-Map/InteractiveClusteringMap/CoreData/CoreDataStack.swift
+++ b/Project17-C-Map/InteractiveClusteringMap/CoreData/CoreDataStack.swift
@@ -24,13 +24,15 @@ final class CoreDataStack: DataManagable {
     private init() {
         context.parent = container?.viewContext
         
-        guard let poiCount = try? container?.viewContext.count(for: POIMO.fetchRequest()),
-              poiCount != 0 else {
-            let pois = JSONReader.readPOIs(fileName: Name.fileName)
-            pois?.forEach {
-                setValue($0)
+        context.perform { [weak self] in
+            guard let poiCount = try? self?.container?.viewContext.count(for: POIMO.fetchRequest()),
+                  poiCount != 0 else {
+                let pois = JSONReader.readPOIs(fileName: Name.fileName)
+                pois?.forEach {
+                    self?.setValue($0)
+                }
+                return
             }
-            return
         }
     }
     


### PR DESCRIPTION
## 구현내용
### [fix]
기존 core data에서 init 을 동기로 처리했기 때문에 많은 데이터를 core data에 넣을 때 소요 시간이 길었음
core data json data init 비동기로 처리로 처리하여 지도 화면을 볼 수 있게 조정

